### PR TITLE
docs: Remove unverified library comparison from PERFORMANCE.md

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -346,16 +346,7 @@ function onRenderCallback(
 - **Cause**: Not cleaning up refs/listeners
 - **Fix**: Ensure proper cleanup in useEffect
 
-## Comparison with Other Libraries
-
-| Library | Discovery Method | Wrapped Support | Performance |
-|---------|-----------------|-----------------|-------------|
-| react-adjustable-panels | Recursive | ✅ Yes | Fast (memoized) |
-| react-resizable-panels | Flat only | ❌ No | Fastest (no traversal) |
-| react-split-pane | Flat only | ❌ No | Fast |
-| allotment | Flat only | ❌ No | Fast |
-
-**Trade-off**: We accept ~5-10% performance overhead for significantly improved developer experience and flexibility.
+**Trade-off**: We accept ~5-10% performance overhead for significantly improved developer experience and flexibility. This overhead is due to recursive child traversal, which enables wrapping components in arbitrary React elements.
 
 ## Future Optimizations
 


### PR DESCRIPTION
## Description

Removes an unverified comparison table from PERFORMANCE.md that made claims about other React panel libraries without actually researching them. This was an error in documentation that should not have been included.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements

## Related Issue

Closes #

## Changes Made

- Removed comparison table claiming other libraries (react-resizable-panels, react-split-pane, allotment) don't support wrapped components
- This comparison was created without:
  - Reading source code of those libraries
  - Testing their features
  - Running any benchmarks
  - Any actual verification
- Kept only the factual statement about this library's trade-off (5-10% overhead for improved DX)

## Testing

- [x] All existing tests pass
- [ ] New tests added for new functionality
- [x] Test coverage maintained or improved
- [x] Manual testing completed

No code changes - documentation only.

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

This comparison table was added during development without proper research. Making claims about competitor libraries without verification is inappropriate and unprofessional. 

The removed table claimed:
- react-resizable-panels: "Flat only", "No wrapped support"
- react-split-pane: "Flat only", "No wrapped support"  
- allotment: "Flat only", "No wrapped support"

None of these claims were verified. If we want to include such comparisons in the future, we should:
1. Read the actual source code
2. Test the features ourselves
3. Run benchmarks if making performance claims
4. Link to evidence/documentation